### PR TITLE
Remove profiles from non root packages

### DIFF
--- a/examples/hermitrust/Cargo.toml
+++ b/examples/hermitrust/Cargo.toml
@@ -16,9 +16,3 @@ rftrace-frontend = { version = "0.1.0", path="../../rftrace-frontend" }
 #hermit-sys = {version="0.1.25", features=["instrument"]}
 hermit-sys = {git="https://github.com/tlambertz/rusty-hermit", branch="master", features=["instrument", "with_submodule"]}
 #hermit-sys = { path = "../../../rusty-hermit/hermit-sys", features = ["with_submodule", "instrument"] }
-
-[profile.release]
-opt-level = 3
-
-[profile.dev]
-opt-level = 1


### PR DESCRIPTION
Fixes:
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   rftrace/examples/hermitrust/Cargo.toml
workspace: rftrace/Cargo.toml
```