### PR TITLE
feat: decouple Rust app's toolchain from rftrace's toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install lld uftrace
       - uses: mkroening/rust-toolchain-toml@main
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2023-11-01
+          components: llvm-tools
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo rustc -- -Zinstrument-mcount -C passes="ee-instrument post-inline-ee-instrument" -C link-arg=-fuse-ld=lld
+        run: cargo +nightly-2023-11-01 rustc -- -Zinstrument-mcount -C passes="ee-instrument<post-inline>" -C link-arg=-fuse-ld=lld
       - name: Run
         run: |
           mkdir tracedir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install uftrace
         run: |
           sudo apt-get update
-          sudo apt-get install uftrace
+          sudo apt-get install lld uftrace
       - uses: mkroening/rust-toolchain-toml@main
       - uses: Swatinem/rust-cache@v2
       - name: Build
@@ -41,11 +41,11 @@ jobs:
       - name: Install uftrace
         run: |
           sudo apt-get update
-          sudo apt-get install uftrace
+          sudo apt-get install lld uftrace
       - uses: mkroening/rust-toolchain-toml@main
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo rustc -- -Zinstrument-mcount -C passes="ee-instrument post-inline-ee-instrument"
+        run: cargo rustc -- -Zinstrument-mcount -C passes="ee-instrument post-inline-ee-instrument" -C link-arg=-fuse-ld=lld
       - name: Run
         run: |
           mkdir tracedir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,12 @@ jobs:
       - name: Install uftrace
         run: |
           sudo apt-get update
-          sudo apt-get install lld uftrace
+          sudo apt-get install uftrace
       - uses: mkroening/rust-toolchain-toml@main
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2023-11-01
+          components: llvm-tools
       - uses: Swatinem/rust-cache@v2
       - name: Build
         run: make
@@ -41,7 +45,7 @@ jobs:
       - name: Install uftrace
         run: |
           sudo apt-get update
-          sudo apt-get install lld uftrace
+          sudo apt-get install uftrace
       - uses: mkroening/rust-toolchain-toml@main
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -49,7 +53,7 @@ jobs:
           components: llvm-tools
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo +nightly-2023-11-01 rustc -- -Zinstrument-mcount -C passes="ee-instrument<post-inline>" -C link-arg=-fuse-ld=lld
+        run: cargo +nightly-2023-11-01 rustc -- -Zinstrument-mcount -C passes="ee-instrument<post-inline>"
       - name: Run
         run: |
           mkdir tracedir

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For RustyHermit there is a workaround with the `autokernel` feature, which can e
 
 Other backend features which might be of interest are:
 - `buildcore` - needed for no-std targets. Will build the core library when building the backend.
-- `interruptsafe` - enabled by default. Will safe and restore more registers on function exits, to ensure interrupts do not clobber them. Probably only needed when interrupts are instrumented. Can be disabled for performance reasons.
+- `interruptsafe` - will safe and restore more registers on function exits, to ensure interrupts do not clobber them. Probably only needed when interrupts are instrumented. Can be disabled for performance reasons.
 
 
 ### Output Format

--- a/README.md
+++ b/README.md
@@ -124,11 +124,7 @@ rftrace = "0.1"
 ```
 
 #### Any other kernel
-Unfortunately, there is no way to communicate a fixed, different compilation-target to the backend. There is an open cargo issue for allowing arbitrary environment variables to be set: [Passing environment variables from down-stream to up-stream library](https://github.com/rust-lang/cargo/issues/4121)
-
-For RustyHermit there is a workaround with the `autokernel` feature, which can easily be extended to other targets. Outside of this, you can also set a custom target by setting the environment variable `RFTRACE_TARGET_TRIPLE` to your wanted triple.
-
-Other backend features which might be of interest are:
+Backend features which might be of interest are:
 - `interruptsafe` - will safe and restore more registers on function exits, to ensure interrupts do not clobber them. Probably only needed when interrupts are instrumented. Can be disabled for performance reasons.
 
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Unfortunately, there is no way to communicate a fixed, different compilation-tar
 For RustyHermit there is a workaround with the `autokernel` feature, which can easily be extended to other targets. Outside of this, you can also set a custom target by setting the environment variable `RFTRACE_TARGET_TRIPLE` to your wanted triple.
 
 Other backend features which might be of interest are:
-- `buildcore` - needed for no-std targets. Will build the core library when building the backend.
 - `interruptsafe` - will safe and restore more registers on function exits, to ensure interrupts do not clobber them. Probably only needed when interrupts are instrumented. Can be disabled for performance reasons.
 
 

--- a/examples/c/makefile
+++ b/examples/c/makefile
@@ -1,5 +1,5 @@
 default: out/debug/librftrace.a out/debug/librftrace_frontend_ffi.a
-	gcc main.c -p -pthread -ldl -lrftrace -lrftrace_frontend_ffi -Lout/debug/ -o test
+	gcc main.c -p -pthread -ldl -lrftrace -lrftrace_frontend_ffi -Lout/debug/ -o test -fuse-ld=lld
 
 out/debug/librftrace.a:
 	cargo build --manifest-path ../../rftrace/Cargo.toml --target-dir out

--- a/examples/c/makefile
+++ b/examples/c/makefile
@@ -1,11 +1,11 @@
 default: out/debug/librftrace.a out/debug/librftrace_frontend_ffi.a
-	gcc main.c -p -pthread -ldl -lrftrace -lrftrace_frontend_ffi -Lout/debug/ -o test -fuse-ld=lld
+	gcc main.c -p -pthread -ldl -lrftrace -lrftrace_frontend_ffi -Lout/debug/ -o test
 
 out/debug/librftrace.a:
-	cargo build --manifest-path ../../rftrace/Cargo.toml --target-dir out
+	cargo +nightly-2023-11-01 build --manifest-path ../../rftrace/Cargo.toml --target-dir out
 
 out/debug/librftrace_frontend_ffi.a:
-	cargo build --manifest-path ../../rftrace-frontend-ffi/Cargo.toml --target-dir out
+	cargo +nightly-2023-11-01 build --manifest-path ../../rftrace-frontend-ffi/Cargo.toml --target-dir out
 
 clean:
 	rm -r out

--- a/examples/hermitc/makefile
+++ b/examples/hermitc/makefile
@@ -24,7 +24,7 @@ $(HERMIT_PATH)/libhermit.a:
 	RUSTFLAGS=$(RUST_FLAGS) cargo build --manifest-path $(LIBHERMIT_SRC)/Cargo.toml -Z build-std=core,alloc --target $(TARGET)-kernel --features newlib  --release --target-dir out
 
 $(LIBRARY_PATH)/librftrace.a:
-	cargo build --manifest-path ../../rftrace/Cargo.toml --target $(TARGET) --features autokernel --target-dir out -Z build-std=std,panic_abort
+	cargo build --manifest-path ../../rftrace/Cargo.toml --target $(TARGET) --target-dir out -Z build-std=std,panic_abort
 
 $(LIBRARY_PATH)/librftrace_frontend_ffi.a:
 	RUSTFLAGS=$(RUST_FLAGS) cargo build --manifest-path ../../rftrace-frontend-ffi/Cargo.toml --target $(TARGET) --target-dir out -Z build-std=std,panic_abort

--- a/examples/hermitc/makefile
+++ b/examples/hermitc/makefile
@@ -24,7 +24,7 @@ $(HERMIT_PATH)/libhermit.a:
 	RUSTFLAGS=$(RUST_FLAGS) cargo build --manifest-path $(LIBHERMIT_SRC)/Cargo.toml -Z build-std=core,alloc --target $(TARGET)-kernel --features newlib  --release --target-dir out
 
 $(LIBRARY_PATH)/librftrace.a:
-	cargo build --manifest-path ../../rftrace/Cargo.toml --target $(TARGET) --features autokernel,buildcore --target-dir out -Z build-std=std,panic_abort
+	cargo build --manifest-path ../../rftrace/Cargo.toml --target $(TARGET) --features autokernel --target-dir out -Z build-std=std,panic_abort
 
 $(LIBRARY_PATH)/librftrace_frontend_ffi.a:
 	RUSTFLAGS=$(RUST_FLAGS) cargo build --manifest-path ../../rftrace-frontend-ffi/Cargo.toml --target $(TARGET) --target-dir out -Z build-std=std,panic_abort

--- a/examples/hermitrust/Cargo.toml
+++ b/examples/hermitrust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rftrace = { version = "0.2.0", path="../../rftrace", features=["autokernel"] }
+rftrace = { version = "0.2.0", path="../../rftrace" }
 rftrace-frontend = { version = "0.1.0", path="../../rftrace-frontend" }
 
 

--- a/examples/hermitrust/Cargo.toml
+++ b/examples/hermitrust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rftrace = { version = "0.2.0", path="../../rftrace", features=["buildcore","autokernel"] }
+rftrace = { version = "0.2.0", path="../../rftrace", features=["autokernel"] }
 rftrace-frontend = { version = "0.1.0", path="../../rftrace-frontend" }
 
 

--- a/examples/rust/out.snap
+++ b/examples/rust/out.snap
@@ -1,11 +1,11 @@
 #   TID     FUNCTION
- [     1] | core::fmt::Arguments::new_v1();
+ [     1] | core::fmt::Arguments::new_const();
  [     1] | rftrace_rs_test::test1() {
- [     1] |   core::fmt::Arguments::new_v1();
+ [     1] |   core::fmt::Arguments::new_const();
  [     1] |   rftrace_rs_test::test2() {
- [     1] |     core::fmt::Arguments::new_v1();
+ [     1] |     core::fmt::Arguments::new_const();
  [     1] |     rftrace_rs_test::test3() {
- [     1] |       core::fmt::Arguments::new_v1();
+ [     1] |       core::fmt::Arguments::new_const();
  [     1] |     } /* rftrace_rs_test::test3 */
  [     1] |   } /* rftrace_rs_test::test2 */
  [     1] | } /* rftrace_rs_test::test1 */

--- a/rftrace/Cargo.toml
+++ b/rftrace/Cargo.toml
@@ -20,7 +20,6 @@ include = [
 
 
 [features]
-buildcore = [] # Build core, needed when compiling against a kernel-target, such as x86_64-unknown-none-hermitkernel.
 autokernel = [] # convenience flag, which specifies compilation target as `x86_64-unknown-none-hermitkernel` when orignal target is `x86_64-unknown-hermit`
 interruptsafe = [] # backup and restore all scratch registers in the mcount_return trampoline. Needed if we instrument interrupt routines
 

--- a/rftrace/Cargo.toml
+++ b/rftrace/Cargo.toml
@@ -29,7 +29,6 @@ crate-type = ['staticlib', 'rlib']
 
 [build-dependencies]
 llvm-tools = "0.1"
-log = "=0.4.18" # TODO: `log v0.4.19 requires rustc 1.60.0 or newer
 
 #[profile.dev]
 #panic = "abort"

--- a/rftrace/Cargo.toml
+++ b/rftrace/Cargo.toml
@@ -20,7 +20,6 @@ include = [
 
 
 [features]
-autokernel = [] # convenience flag, which specifies compilation target as `x86_64-unknown-none-hermitkernel` when orignal target is `x86_64-unknown-hermit`
 interruptsafe = [] # backup and restore all scratch registers in the mcount_return trampoline. Needed if we instrument interrupt routines
 
 default = []

--- a/rftrace/Cargo.toml
+++ b/rftrace/Cargo.toml
@@ -28,6 +28,10 @@ default = []
 [lib]
 crate-type = ['staticlib', 'rlib']
 
+[build-dependencies]
+llvm-tools = "0.1"
+log = "=0.4.18" # TODO: `log v0.4.19 requires rustc 1.60.0 or newer
+
 #[profile.dev]
 #panic = "abort"
 # # we have to build with at least opt-level 1. Might aswell do always 3, since mcount() is in the hotpath!

--- a/rftrace/build.rs
+++ b/rftrace/build.rs
@@ -128,14 +128,16 @@ fn main() {
 // Adapted from Hermit.
 fn cargo() -> Command {
     let cargo = {
+        let exe = format!("cargo{}", env::consts::EXE_SUFFIX);
         // On windows, the userspace toolchain ends up in front of the rustup proxy in $PATH.
         // To reach the rustup proxy nonetheless, we explicitly query $CARGO_HOME.
         let mut cargo_home = PathBuf::from(env::var_os("CARGO_HOME").unwrap());
-        cargo_home.push("bin/cargo");
+        cargo_home.push("bin");
+        cargo_home.push(&exe);
         if cargo_home.exists() {
             cargo_home
         } else {
-            PathBuf::from("cargo")
+            PathBuf::from(exe)
         }
     };
 

--- a/rftrace/build.rs
+++ b/rftrace/build.rs
@@ -81,10 +81,10 @@ fn build_backend() {
     cmd.stdout(Stdio::inherit());
     cmd.stderr(Stdio::inherit());
 
-    // Build core, needed when compiling against a kernel-target, such as x86_64-unknown-none-hermitkernel.
-    // parent's cargo does NOT expose -Z flags as envvar, we therefore use a feature flag for this
-    #[cfg(feature = "buildcore")]
-    cmd.args(&["-Z", "build-std=core"]); // should be build std,alloc?
+    cmd.args(&[
+        "-Zbuild-std=core",
+        "-Zbuild-std-features=compiler-builtins-mem",
+    ]);
 
     // Compile staticlib as release if included in release build.
     if profile == "release" {

--- a/rftrace/build.rs
+++ b/rftrace/build.rs
@@ -32,29 +32,12 @@ fn build_backend() {
     let full_target_dir = format!("{}/target_static", out_dir);
     let profile = env::var("PROFILE").expect("PROFILE was not set");
 
-    // Set the target. Can be overwritten via env-var.
-    // If feature autokernel is enabled, automatically 'convert' hermit to hermit-kernel target.
-    let target = {
-        println!("cargo:rerun-if-env-changed=RFTRACE_TARGET_TRIPLE");
-        env::var("RFTRACE_TARGET_TRIPLE").unwrap_or_else(|_| {
-            let default = env::var("TARGET").unwrap();
-            #[cfg(not(feature = "autokernel"))]
-            return default;
-            #[cfg(feature = "autokernel")]
-            if default == "x86_64-unknown-hermit" {
-                "x86_64-unknown-none-hermitkernel".to_owned()
-            } else {
-                default
-            }
-        })
-    };
-    println!("Compiling for target {}", target);
+    let target = "x86_64-unknown-none";
 
     let mut cmd = cargo();
     cmd.arg("build");
 
-    // Compile for the same target as the parent-lib
-    cmd.args(&["--target", &target]);
+    cmd.args(&["--target", target]);
 
     // Output all build artifacts in output dir of parent-lib
     cmd.args(&["--target-dir", &full_target_dir]);

--- a/rftrace/src/backend.rs
+++ b/rftrace/src/backend.rs
@@ -39,11 +39,8 @@ static mut TID: Option<core::num::NonZeroU64> = None;
 // Everytime we see a new thread (with emtpy thread-locals), we alloc out own TID
 static mut TID_NEXT: AtomicU64 = AtomicU64::new(1);
 
-// Need to define own panic handler, since we are no_std
-use core::panic::PanicInfo;
-#[linkage = "weak"]
 #[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 

--- a/rftrace/src/lib.rs
+++ b/rftrace/src/lib.rs
@@ -2,10 +2,10 @@
 //! Provides an `mcount` implementation, which does nothing by default but can be enabled via frontend.
 //! A lot of documentation can be found in the parent workspaces [readme](https://github.com/tlambertz/rftrace).
 
-#![feature(naked_functions)]
-#![feature(llvm_asm)]
-#![feature(thread_local)]
-#![feature(linkage)]
+#![cfg_attr(feature = "staticlib", feature(naked_functions))]
+#![cfg_attr(feature = "staticlib", feature(llvm_asm))]
+#![cfg_attr(feature = "staticlib", feature(thread_local))]
+#![cfg_attr(feature = "staticlib", feature(linkage))]
 #![cfg_attr(feature = "staticlib", no_std)]
 
 mod interface;

--- a/rftrace/src/lib.rs
+++ b/rftrace/src/lib.rs
@@ -5,7 +5,6 @@
 #![cfg_attr(feature = "staticlib", feature(naked_functions))]
 #![cfg_attr(feature = "staticlib", feature(llvm_asm))]
 #![cfg_attr(feature = "staticlib", feature(thread_local))]
-#![cfg_attr(feature = "staticlib", feature(linkage))]
 #![cfg_attr(feature = "staticlib", no_std)]
 
 mod interface;


### PR DESCRIPTION
This PR decouples the Rust app's toolchain from rftrace's toolchain, allowing you to use a recent nightly version for the Rust app.

The approach is the same that we use for Hermit nowadays: properly bundle `core` and         `compiler-builtins-mem` in the static library, but only export explicit symbols. All other symbols are renamed to avoid duplicated symbols from `core`, which recent Rust toolchains reject.

This PR allows me to compile and run rftrace with recent Hermit versions.
I will still rework rftrace for recent Rust versions itself later, though.

This PR is best reviewed commit by commit.

Closes https://github.com/tlambertz/rftrace/issues/17