### PR TITLE
fix(backend): remove non-asm code from naked mcount

### DIFF
--- a/rftrace/src/backend.rs
+++ b/rftrace/src/backend.rs
@@ -382,6 +382,7 @@ pub extern "C" fn mcount_return_trampoline() {
         ); // here we added same amount back we substracted, since space is in rax push.
         #[cfg(feature = "interruptsafe")]
         llvm_asm!("popfq"); // This should also restore the interrupt flag?
+        llvm_asm!("ret");
     }
 }
 

--- a/rftrace/src/backend.rs
+++ b/rftrace/src/backend.rs
@@ -19,7 +19,7 @@ struct SavedRet {
 
 static ENABLED: AtomicBool = AtomicBool::new(false);
 static OVERWRITING: AtomicBool = AtomicBool::new(false); // should the ring-buffer be overwritten once full?
-static mut INDEX: AtomicUsize = AtomicUsize::new(0);
+static INDEX: AtomicUsize = AtomicUsize::new(0);
 static mut EVENTS: Option<&mut [Event]> = None;
 
 // !! Will always be initialized to all 0 by the OS, no matter what. This is just to make the compiler happy
@@ -424,7 +424,7 @@ fn set_eventbuf(eventbuf: &'static mut [Event]) {
 
 #[no_mangle]
 pub extern "C" fn rftrace_backend_get_events_index() -> usize {
-    return unsafe { INDEX.load(Ordering::Relaxed) };
+    return INDEX.load(Ordering::Relaxed);
 }
 
 #[no_mangle]


### PR DESCRIPTION
As a first step towards reworking the backend, this PR makes a few statics sound by migrating them to atomics and removes all non-asm code from all naked functions.

Closes https://github.com/tlambertz/rftrace/issues/9