### PR TITLE
mcount_return_trampoline: Add RFLAGS to stack layout

### DIFF
--- a/rftrace/src/backend.rs
+++ b/rftrace/src/backend.rs
@@ -243,8 +243,9 @@ pub extern "C" fn mcount_return_trampoline() {
 
     /*
     Stack layout:
-        RBP +112
-            +104    RETURN-ADDRESS
+        RBP +120
+            +112    RETURN-ADDRESS
+            +104    rflags   |
             +96     r11      |
             +88     r10      |
             +80     r9       |


### PR DESCRIPTION
Cherry-picked the second commit from https://github.com/tlambertz/rftrace/pull/10.