### PR TITLE
specify the toolchain for which llvm-tools is to be installed

### DIFF
--- a/rftrace/build.rs
+++ b/rftrace/build.rs
@@ -182,9 +182,9 @@ fn binutil(name: &str) -> Result<PathBuf, String> {
     let path = llvm_tools::LlvmTools::new()
 		.map_err(|err| match err {
 			llvm_tools::Error::NotFound =>
-				"Could not find llvm-tools component\n\
+				format!("Could not find llvm-tools component\n\
 				\n\
-				Maybe the rustup component `llvm-tools` is missing? Install it through: `rustup component add llvm-tools`".to_string()
+				Maybe the rustup component `llvm-tools` is missing? Install it through: `rustup component add --toolchain={} llvm-tools`", env::var("RUSTUP_TOOLCHAIN").unwrap()).to_string()
 			,
 			err => format!("{err:?}"),
 		})?


### PR DESCRIPTION
If the user is in a project with a different toolchain than the one rftrace is being built with, the component install without the toolchain argument defaults to the wrong toolchain. This change makes the error message provide the possibly necessary argument.