### PR TITLE
fix(build.rs): use canonical `cargo_home` location

### DIFF
--- a/rftrace/Cargo.toml
+++ b/rftrace/Cargo.toml
@@ -31,6 +31,7 @@ default = []
 crate-type = ['staticlib', 'rlib']
 
 [build-dependencies]
+home = "0.5"
 llvm-tools = "0.1"
 
 #[profile.dev]

--- a/rftrace/build.rs
+++ b/rftrace/build.rs
@@ -99,7 +99,7 @@ fn sanitize(cmd: &str) -> Command {
         let exe = format!("{cmd}{}", env::consts::EXE_SUFFIX);
         // On windows, the userspace toolchain ends up in front of the rustup proxy in $PATH.
         // To reach the rustup proxy nonetheless, we explicitly query $CARGO_HOME.
-        let mut cargo_home = PathBuf::from(env::var_os("CARGO_HOME").unwrap());
+        let mut cargo_home = home::cargo_home().unwrap();
         cargo_home.push("bin");
         cargo_home.push(&exe);
         if cargo_home.exists() {


### PR DESCRIPTION
See https://github.com/hermit-os/kernel/pull/1539.