### PR TITLE
chore: remove naked_functions cfg_attr

### DIFF
--- a/rftrace/src/lib.rs
+++ b/rftrace/src/lib.rs
@@ -2,7 +2,6 @@
 //! Provides an `mcount` implementation, which does nothing by default but can be enabled via frontend.
 //! A lot of documentation can be found in the parent workspaces [readme](https://github.com/hermit-os/rftrace).
 
-#![cfg_attr(feature = "staticlib", feature(naked_functions))]
 #![cfg_attr(feature = "staticlib", feature(thread_local))]
 #![cfg_attr(feature = "staticlib", no_std)]
 


### PR DESCRIPTION
Stabilized starting from 1.88-nightly.

See: https://github.com/rust-lang/rust/pull/134213