### PR TITLE
ci: don't run on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 


### PR DESCRIPTION
We can skip this thanks to https://github.com/hermit-os/rftrace/pull/53.