### PR TITLE
feat(frontend): Allow `Path`'s as outdir

### DIFF
--- a/examples/rust/out.snap
+++ b/examples/rust/out.snap
@@ -11,13 +11,18 @@
  [     1] |     } /* rftrace_rs_test::test3 */
  [     1] |   } /* rftrace_rs_test::test2 */
  [     1] | } /* rftrace_rs_test::test1 */
- [     1] | rftrace_frontend::frontend::dump_full_uftrace() {
- [     1] |   rftrace_frontend::frontend::dump_traces() {
- [     1] |     rftrace_frontend::frontend::disable();
+ [     1] | rftrace_frontend::frontend::dump_full_uftrace::<&str>() {
+ [     1] |   <&str as core::convert::AsRef<std::path::Path>>::as_ref() {
+ [     1] |     <str as core::convert::AsRef<std::path::Path>>::as_ref();
+ [     1] |   } /* <&str as core::convert::AsRef<std::path::Path>>::as_ref */
+ [     1] |   rftrace_frontend::frontend::dump_full_uftrace_inner() {
+ [     1] |     rftrace_frontend::frontend::dump_traces() {
+ [     1] |       rftrace_frontend::frontend::disable();
 
 uftrace stopped tracing with remaining functions
 ================================================
 task: 1
-[1] rftrace_frontend::frontend::dump_traces
-[0] rftrace_frontend::frontend::dump_full_uftrace
+[2] rftrace_frontend::frontend::dump_traces
+[1] rftrace_frontend::frontend::dump_full_uftrace_inner
+[0] rftrace_frontend::frontend::dump_full_uftrace::<&str>
 

--- a/rftrace-frontend-ffi/src/lib.rs
+++ b/rftrace-frontend-ffi/src/lib.rs
@@ -7,6 +7,7 @@
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
+use std::path::Path;
 
 pub type Events = rftrace_frontend::Events;
 
@@ -28,6 +29,22 @@ pub unsafe extern "C" fn rftrace_init(max_event_count: usize, overwriting: bool)
     rftrace_frontend::init(max_event_count, overwriting)
 }
 
+fn try_path_from_c_str(c_str: &CStr) -> Option<&Path> {
+    let bytes = c_str.to_bytes();
+
+    cfg_select! {
+        unix => {
+            use std::os::unix::ffi::OsStrExt;
+            use std::ffi::OsStr;
+
+            Some(OsStr::from_bytes(bytes).as_ref())
+        }
+        _ => {
+            str::from_utf8(bytes).ok().map(|s| s.as_ref())
+        }
+    }
+}
+
 #[no_mangle]
 /// Wraps rftrace_frontend::dump_full_uftrace
 pub unsafe extern "C" fn rftrace_dump_full_uftrace(
@@ -35,10 +52,12 @@ pub unsafe extern "C" fn rftrace_dump_full_uftrace(
     out_dir: *const c_char,
     binary_name: *const c_char,
 ) -> i64 {
-    let out_dir = CStr::from_ptr(out_dir).to_string_lossy().into_owned();
+    let Some(out_dir) = try_path_from_c_str(CStr::from_ptr(out_dir)) else {
+        return -1;
+    };
     let binary_name = CStr::from_ptr(binary_name).to_string_lossy().into_owned();
 
-    if rftrace_frontend::dump_full_uftrace(&mut *events, &out_dir, &binary_name).is_err() {
+    if rftrace_frontend::dump_full_uftrace(&mut *events, out_dir, &binary_name).is_err() {
         return -1;
     }
     0
@@ -47,9 +66,11 @@ pub unsafe extern "C" fn rftrace_dump_full_uftrace(
 #[no_mangle]
 /// Wraps rftrace_frontend::dump_trace
 pub unsafe extern "C" fn rftrace_dump_trace(events: *mut Events, outfile: *const c_char) -> i64 {
-    let outfile = CStr::from_ptr(outfile).to_string_lossy().into_owned();
+    let Some(outfile) = try_path_from_c_str(CStr::from_ptr(outfile)) else {
+        return -1;
+    };
 
-    if rftrace_frontend::dump_trace(&mut *events, &outfile).is_err() {
+    if rftrace_frontend::dump_trace(&mut *events, outfile).is_err() {
         return -1;
     }
     0

--- a/rftrace-frontend/src/frontend.rs
+++ b/rftrace-frontend/src/frontend.rs
@@ -98,7 +98,7 @@ pub fn dump_full_uftrace(events: &mut Events, out_dir: &str, binary_name: &str) 
 
     // /info HEADER
     // magic
-    info.extend("Ftrace!\x00".as_bytes());
+    info.extend(b"Ftrace!\x00");
     // version. we are using version 4 of fileformat
     info.write_u32::<LittleEndian>(4)
         .expect("Write interrupted");

--- a/rftrace-frontend/src/frontend.rs
+++ b/rftrace-frontend/src/frontend.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::prelude::*;
+use std::path::Path;
 use std::{io, mem};
 
 use byteorder::{LittleEndian, WriteBytesExt};
@@ -78,7 +79,19 @@ pub fn init(max_event_count: usize, overwriting: bool) -> &'static mut Events {
 /// * `out_dir` - folder into which the resulting trace is dumped. Has to exist.
 /// * `binary_name` - only relevant for this symbol file. Generated metadata instructs uftrace where to look for it.
 ///
-pub fn dump_full_uftrace(events: &mut Events, out_dir: &str, binary_name: &str) -> io::Result<()> {
+pub fn dump_full_uftrace<P: AsRef<Path>>(
+    events: &mut Events,
+    out_dir: P,
+    binary_name: &str,
+) -> io::Result<()> {
+    dump_full_uftrace_inner(events, out_dir.as_ref(), binary_name)
+}
+
+fn dump_full_uftrace_inner(
+    events: &mut Events,
+    out_dir: &Path,
+    binary_name: &str,
+) -> io::Result<()> {
     // arbitrary values for pid and sid
     let pid = 42;
     let sid = "00";
@@ -91,7 +104,7 @@ pub fn dump_full_uftrace(events: &mut Events, out_dir: &str, binary_name: &str) 
         return Ok(());
     }
 
-    println!("Creating fake uftrace data dir at {}..", out_dir);
+    println!("Creating fake uftrace data dir at {}..", out_dir.display());
     println!("  Creating ./info");
     let mut info: Vec<u8> = Vec::new();
 
@@ -145,13 +158,13 @@ pub fn dump_full_uftrace(events: &mut Events, out_dir: &str, binary_name: &str) 
     }
     writeln!(info)?;
 
-    let infofile = format!("{}/info", out_dir);
+    let infofile = out_dir.join("info");
     let mut infofile = File::create(infofile)?;
     infofile.write_all(&info[..])?;
     drop(infofile);
 
     println!("  Creating ./task.txt");
-    let taskfile = format!("{}/task.txt", out_dir);
+    let taskfile = out_dir.join("task.txt");
     let mut taskfile = File::create(taskfile)?;
     println!("    pid = {}", pid);
     println!("    sid = {}", sid);
@@ -166,7 +179,7 @@ pub fn dump_full_uftrace(events: &mut Events, out_dir: &str, binary_name: &str) 
     }
     drop(taskfile);
 
-    let mapfilename = format!("{}/sid-{}.map", out_dir, sid);
+    let mapfilename = out_dir.join(format!("sid-{}.map", sid));
     let mut mapfile = File::create(mapfilename)?;
     cfg_if::cfg_if! {
         if #[cfg(target_os = "linux")] {
@@ -198,7 +211,7 @@ pub fn dump_full_uftrace(events: &mut Events, out_dir: &str, binary_name: &str) 
     if cfg!(target_os = "linux") {
         println!(
             "\nYou should generate symbols with `nm --demangle -n $BINARY > {}/$BINARY.sym`",
-            out_dir
+            out_dir.display()
         );
         println!(
             "INFO: Linux mode is NOT fully supported yet! To get symbols working, you have to"
@@ -208,7 +221,8 @@ pub fn dump_full_uftrace(events: &mut Events, out_dir: &str, binary_name: &str) 
     } else {
         println!(
             "\nYou should generate symbols with `nm --demangle -n $BINARY > {}/{}.sym`",
-            out_dir, binary_name
+            out_dir.display(),
+            binary_name
         );
     }
 
@@ -232,12 +246,11 @@ pub fn dump_full_uftrace(events: &mut Events, out_dir: &str, binary_name: &str) 
 ///     uint64_t depth:  10;
 ///     uint64_t addr:   48; /* child ip or uftrace_event_id */
 /// };
-pub fn dump_trace(events: &mut Events, outfile: &str) -> io::Result<()> {
-    dump_traces(events, outfile, true)?;
-    Ok(())
+pub fn dump_trace<P: AsRef<Path>>(events: &mut Events, outfile: P) -> io::Result<()> {
+    dump_traces(events, outfile.as_ref(), true).map(|_| ())
 }
 
-fn dump_traces(events: &mut Events, outpath: &str, singlefile: bool) -> io::Result<Vec<u64>> {
+fn dump_traces(events: &mut Events, outpath: &Path, singlefile: bool) -> io::Result<Vec<u64>> {
     // Uftraces trace format: a bunch of 64-bit fields, See https://github.com/namhyung/uftrace/wiki/Data-Format
     //
     // Array of 2x64 bit unsigned long: `[{time: u64, address: u64}, ...]`
@@ -316,15 +329,14 @@ fn dump_traces(events: &mut Events, outpath: &str, singlefile: bool) -> io::Resu
             let filename = if singlefile {
                 outpath.into()
             } else {
-                let file = format!("{}.dat", tid);
-                format!("{}/{}", outpath, file)
+                outpath.join(format!("{}.dat", tid))
             };
 
             println!(
                 "  Writing to disk: {} events, {} bytes ({})",
                 out.len() / 16,
                 out.len(),
-                filename
+                filename.display(),
             );
             let mut file = File::create(filename)?;
             file.write_all(&out[..])?;

--- a/rftrace-frontend/src/frontend.rs
+++ b/rftrace-frontend/src/frontend.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::prelude::*;
-use std::io::{self};
-use std::mem;
+use std::{io, mem};
 
 use byteorder::{LittleEndian, WriteBytesExt};
 


### PR DESCRIPTION
This previously was a bit of a sore thumb in the middle of `uhyve` String / path handling.